### PR TITLE
EE-18783 Added the coreutils to the pttg-vault-sidekick image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER root
 COPY scripts/trigger_nginx_reload.sh /usr/local/scripts/trigger_nginx_reload.sh
 RUN chmod +x /usr/local/scripts/trigger_nginx_reload.sh
 RUN apk update && \
-    apk add ca-certificates wget apache2-utils openssl
+    apk add ca-certificates wget apache2-utils openssl coreutils
 
 RUN addgroup ${GROUP} && \
     adduser -D ${USER} -g ${GROUP} -u ${USER_ID}5


### PR DESCRIPTION
Did this so that the date command is the better GNU Core Utils one, not the lightweight BusyBox one. This is needed for parsing expiry dates of certificates