### PR TITLE
EE-26626 Adding curl and jq to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER root
 COPY scripts/trigger_nginx_reload.sh /usr/local/scripts/trigger_nginx_reload.sh
 RUN chmod +x /usr/local/scripts/trigger_nginx_reload.sh
 RUN apk update && \
-    apk add ca-certificates wget apache2-utils openssl coreutils
+    apk add ca-certificates wget apache2-utils openssl coreutils curl jq
 
 RUN addgroup ${GROUP} && \
     adduser -D ${USER} -g ${GROUP} -u ${USER_ID}5


### PR DESCRIPTION
Doing this so that I can get the Vault PKI CA out of vault as per https://confluence.ipttools.info/display/EN/Using+the+PKI+backend#UsingthePKIbackend-Addingthetrust. I intend to merge once approved.