### PR TITLE
EE-2809 Updating the version of vault-sidekick on which this image is built to v0.3.13.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/vault-sidekick:v0.3.8
+FROM quay.io/ukhomeofficedigital/vault-sidekick:v0.3.13
 
 LABEL maintainer="Tim.Hammonds@digital.homeoffice.gov.uk"
 


### PR DESCRIPTION
This should mean that Vault PKI certificates can be provisioned with the whole cert chain.

We explicitly state which version of this application we use in eue-api-helm-project so this change won't automatically be picked up. For this reason I intend to merge once approved.